### PR TITLE
🐞 Fix passing of absolute URIs to GoatCounter

### DIFF
--- a/assets/js/pageTransitions.js
+++ b/assets/js/pageTransitions.js
@@ -44,13 +44,8 @@ function loadPage(url, shouldPushState = false, scrollPosition = 0)
 
             // Count as pageview in analytics
             try {
-                if (window.goatcounter && window.goatcounter.count) {
-                    window.goatcounter.count({
-                        path: url,
-                    });
-                }
+                window.goatcounter?.count();
             } catch (e) {
-                // Silently ignore analytics errors
                 console.warn('GoatCounter tracking failed:', e);
             }
         });


### PR DESCRIPTION
I was passing absolute URLs to GoatCounter, which was screwing up analytics. If I stop passing a path entirely, GoatCounter figures it out by itself.