### PR TITLE
🎞️ Fix videos not showing in Firefox

### DIFF
--- a/assets/js/pageTransitions.js
+++ b/assets/js/pageTransitions.js
@@ -23,7 +23,7 @@ function loadPage(url, shouldPushState = false, scrollPosition = 0)
             // Wait for transition to finish if we're too early
             var completeUpdate = () => {
                 // Only replace body and update title (don't re-run scripts or CSS)
-                document.body.replaceWith(newDoc.body);
+                document.body.innerHTML = newDoc.body.innerHTML;
                 hookLinks();
                 window.scroll(0, scrollPosition);
 


### PR DESCRIPTION
For some reason, replacing the `<body>` node prevented Firefox from properly loading `<video>` tags. Updating the existing body's `innerHTML` instead seems to fix the issue.